### PR TITLE
Kubernetes debug

### DIFF
--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,49 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "label"
+              - name: "POD_IDENTIFIER_LABEL"
+                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}
+

--- a/kubernetes-debug/kit/kit-clusterrole.yaml
+++ b/kubernetes-debug/kit/kit-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]

--- a/kubernetes-debug/kit/kit-clusterrolebinding.yaml
+++ b/kubernetes-debug/kit/kit-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/kit-serviceaccount.yaml
+++ b/kubernetes-debug/kit/kit-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/netperf-operator/deploy/cr.yaml
+++ b/kubernetes-debug/netperf-operator/deploy/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/netperf-operator/deploy/crd.yaml
+++ b/kubernetes-debug/netperf-operator/deploy/crd.yaml
@@ -27,3 +27,14 @@ spec:
               properties:
                 name:
                   type: string
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                serverNode:
+                  type: string
+                clientNode:
+                  type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/kubernetes-debug/netperf-operator/deploy/crd.yaml
+++ b/kubernetes-debug/netperf-operator/deploy/crd.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string

--- a/kubernetes-debug/netperf-operator/deploy/operator.yaml
+++ b/kubernetes-debug/netperf-operator/deploy/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/netperf-operator/deploy/rbac.yaml
+++ b/kubernetes-debug/netperf-operator/deploy/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Выполнено ДЗ №23

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:

Запускаем minikube
```bash
minikube start
```
### strace

Устанавливаем kubectl-debug - https://github.com/aylei/kubectl-debug#install-the-kubectl-debug-plugin

Запускаем поды с агентом kubectl-debug (манифест по ссылке из ДЗ не работает)
```bash
kubectl apply -f \
  https://raw.githubusercontent.com/aylei/kubectl-debug/master/scripts/agent_daemonset.yml
```

Запускаем под с nginx
```bash
kubectl run nginx --image=nginx
```
Запускаем "отладчик"
```bash
kubectl-debug nginx
# При первом запуске отображается ошибка
# error: Internal error occurred: error attaching to container: Error: No such image: nicolaka/netshoot:latest
# Необходимо предварительно выполнить команду
# kubectl-debug nginx --agent-image=aylei/debug-agent:v0.1.1 --agentless=true
# потом можно выполнять `kubectl-debug nginx`
```


```
kubectl-debug nginx
container created, open tty...
nginx:~# ps
PID   USER     TIME  COMMAND
    1 root      0:00 nginx: master process nginx -g daemon off;
   29 101       0:00 nginx: worker process
   30 101       0:00 nginx: worker process
   31 101       0:00 nginx: worker process
   32 101       0:00 nginx: worker process
   33 101       0:00 nginx: worker process
   34 101       0:00 nginx: worker process
   35 101       0:00 nginx: worker process
   36 101       0:00 nginx: worker process
   37 101       0:00 nginx: worker process
   38 101       0:00 nginx: worker process
   39 101       0:00 nginx: worker process
   40 101       0:00 nginx: worker process
   41 101       0:00 nginx: worker process
   42 101       0:00 nginx: worker process
   43 101       0:00 nginx: worker process
   44 101       0:00 nginx: worker process
   88 root      0:00 bash
   94 root      0:00 ps
nginx:~# strace -p 1
strace: Process 1 attached
rt_sigsuspend([], 8
^Cstrace: Process 1 detached
 <detached ...>

nginx:~# 
```
### iptables-tailer

https://github.com/express42/otus-platform-snippets/tree/master/Module-03/Debugging
https://github.com/box/kube-iptables-tailer

Устанавливаем ресурсы из директории *deploy* проекта https://github.com/piontec/netperf-operator. Ожидаемо, ресурсы не завелись. Дорабатываем, складируем в директорию *kubernetes-debug/netperf-operator/deploy*. 
```bash
kubectl apply -f kubernetes-debug/netperf-operator/deploy/crd.yaml
kubectl apply -f kubernetes-debug/netperf-operator/deploy/rbac.yaml
kubectl apply -f kubernetes-debug/netperf-operator/deploy/operator.yaml
```
Применяем манифест CustomResource
```bash
kubectl apply  -f kubernetes-debug/netperf-operator/deploy/cr.yaml
```
На несколько секунд запускаются два пода: *netperf-server* и *netperf-client*.
Смотрим в описание созданного CR *example*
```yaml
apiVersion: app.example.com/v1alpha1
kind: Netperf
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"app.example.com/v1alpha1","kind":"Netperf","metadata":{"annotations":{},"name":"example","namespace":"default"}}
  creationTimestamp: "2023-02-16T14:17:34Z"
  generation: 4
  name: example
  namespace: default
  resourceVersion: "10448"
  uid: dd557e80-0f12-47bb-86fd-d02486e313e1
spec:
  clientNode: ""
  serverNode: ""
status:
  clientPod: netperf-client-d02486e313e1
  serverPod: netperf-server-d02486e313e1
  speedBitsPerSec: 6620.66
  status: Done
```

Включаем сетевую политику
```bash
kubectl apply -f https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-03/Debugging/netperf-calico-policy.yaml
# --- or
kubectl apply -f kubernetes-debug/kit/netperf-calico-policy.yaml
```

Данный ресурс не отображается в сетевых политиках, потому что это CRD
```bash
kubectl get networkpolicy --all-namespaces
No resources found
kubectl get networkpolicies.crd.projectcalico.org
NAME                    AGE
netperf-calico-policy   6m41s
```

Повторно выполняет проверку (запускаем cr)
```bash
kubectl apply  -f kubernetes-debug/netperf-operator/deploy/cr.yaml
```
Тест завис
```bash
apiVersion: app.example.com/v1alpha1
kind: Netperf
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"app.example.com/v1alpha1","kind":"Netperf","metadata":{"annotations":{},"name":"example","namespace":"default"}}
  creationTimestamp: "2023-02-16T17:13:55Z"
  generation: 3
  name: example
  namespace: default
  resourceVersion: "57637"
  uid: 7f149857-546e-49c6-8199-1d58f008dca0
spec:
  clientNode: ""
  serverNode: ""
status:
  clientPod: netperf-client-1d58f008dca0
  serverPod: netperf-server-1d58f008dca0
  speedBitsPerSec: 0
  status: Started test
```

Диагностировать такое дело неудобно. Только через логи сервисов на ноде.

```bash
journalctl -k | grep calico-packet
# ...
Feb 16 18:58:18 cl1ofbo8fhc6osutr49v-yryg kernel: calico-packet: IN=calic9bca733fd4 OUT=cali9fb5fada5e5 MAC=ee:ee:ee:ee:ee:ee:02:a8:6c:04:d0:3c:08:00 SRC=10.112.128.35 DST=10.112.128.34 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=26953 DF PROTO=TCP SPT=54001 DPT=12865 WINDOW=64240 RES=0x00 SYN URGP=0 
Feb 16 18:58:51 cl1ofbo8fhc6osutr49v-yryg kernel: calico-packet: IN=calic9bca733fd4 OUT=cali9fb5fada5e5 MAC=ee:ee:ee:ee:ee:ee:02:a8:6c:04:d0:3c:08:00 SRC=10.112.128.35 DST=10.112.128.34 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=26954 DF PROTO=TCP SPT=54001 DPT=12865 WINDOW=64240 RES=0x00 SYN URGP=0
```

Поэтому лучше использовать *iptables-tailer* (см. ссылку в начале подраздела)

```bash
kubectl apply -f kubernetes-debug/kit/kit-serviceaccount.yaml
kubectl apply -f kubernetes-debug/kit/kit-clusterrole.yaml
kubectl apply -f kubernetes-debug/kit/kit-clusterrolebinding.yaml
kubectl apply -f kubernetes-debug/kit/iptables-tailer.yaml
```
Повторно выполняет проверку (запускаем cr)
```bash
kubectl apply  -f kubernetes-debug/netperf-operator/deploy/cr.yaml
```

Солгласно ДЗ, в разделе *Events* оператора *netperf* должны появиться события от  *kube-iptables-tailer*.
```bash
WarningPacketDrop	70s		kube-iptables-tailer	Packet dropped whenreceiving traffic from 10.48.0.14
```
но собиятия не появились.
При этом имеем ошибки на поде *kube-iptables-tailer*, который запущен на ноде *netperf-client*-а
```bash
E0216 19:04:47.721183       1 poster.go:71] Error retrying packet drop handling, backing off: packetDrop={LogTime:2023-02-16T18:57:46.840435+00:00 HostName:cl1ofbo8fhc6osutr49v-yryg SrcI │
│ P:10.112.128.35 DstIP:10.112.128.34}, retryIn=selfLink was empty, can't make reference secs, error=68.91130502
```

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
